### PR TITLE
Convert protocol.__all__ to a tuple

### DIFF
--- a/protocol/__init__.py
+++ b/protocol/__init__.py
@@ -6,9 +6,9 @@ These classes are designed for use by both frontend and backend applications.
 from .solution import Solution, SolutionRequest, SolutionResponse
 from .tiles import TilesResponse
 
-__all__ = [
+__all__ = (
     "Solution",
     "SolutionRequest",
     "SolutionResponse",
     "TilesResponse",
-]
+)


### PR DESCRIPTION
Just some nice standardisation, generally it is a tuple as it should not be modified at runtime.
